### PR TITLE
fix regex to match any numeric or infinity value in interval notation

### DIFF
--- a/R/agg_scale.R
+++ b/R/agg_scale.R
@@ -446,6 +446,11 @@ assert_agg_scale_args <- function(dt,
     assertable::assert_colnames(mapping, expected_mapping_cols, only_colnames = T,
                                 quiet = T)
     assert_is_unique_dt(mapping, expected_mapping_cols)
+  } else {
+    assertthat::assert_that(assertive::is_null(mapping),
+                            msg = "When scaling an interval variable `mapping`
+                                   must be Null. `mapping` is inferred from
+                                   `dt`")
   }
 
   # check `agg_function` argument

--- a/R/categorical_trees.R
+++ b/R/categorical_trees.R
@@ -318,13 +318,20 @@ identify_missing_agg <- function(tree) {
 #' @rdname problematic_tree_nodes
 identify_missing_scale <- function(tree) {
 
+  if (all(c("left", "right") %in% tree$fields)) {
+    col_type <- "interval"
+  } else {
+    col_type <- "categorical"
+  }
+
   # identify each node that is missing which causes scaling of itself or
   # children to not be possible
   missing_nodes <- tree$Get(
     "name",
     filterFun = function(x) !data.tree::GetAttribute(x, "exists") &
       (!data.tree::GetAttribute(x, "scale_possible") |
-         !data.tree::GetAttribute(x, "scale_children_possible"))
+         !data.tree::GetAttribute(x, "scale_children_possible")) &
+      ifelse(col_type == "interval", data.tree::isNotRoot(x), TRUE)
   )
   if (!is.null(missing_nodes)) missing_nodes <- sort(unname(missing_nodes))
   return(missing_nodes)

--- a/R/interval_formatting.R
+++ b/R/interval_formatting.R
@@ -292,16 +292,30 @@ name_to_start_end <- function(name) {
   # Validate arguments ------------------------------------------------------
 
   # check `name` argument
-  assertthat::assert_that(assertive::is_character(name),
-                          all(grepl("^\\[[0-9]+,\\s[Inf|0-9]+\\)", name)),
-                          msg = "`name` must be a character vector formatted in
-                          left-closed, right-open interval notation as described
-                          in `gen_name()`")
+  assertthat::assert_that(
+    assertive::is_character(name),
+    all(grepl("^\\[((-*Inf)|([\\-\\.0-9]+)),\\s((Inf)|([\\-\\.0-9]+))\\)$",
+              name)),
+    msg = "`name` must be a character vector formatted in left-closed,
+    right-open interval notation as described in `gen_name()`"
+  )
 
   # Parse start and end of interval -----------------------------------------
 
-  start <- as.numeric(gsub("^\\[|,\\s\\w+\\)", "", name))
-  end <- as.numeric(gsub("^\\[[0-9]+,\\s|\\)", "", name))
+  # remove left "["
+  start <- gsub("^\\[", "", name)
+  # remove ", ", right endpoint, right ")".
+  # right endpoint can be positive infinity or any numeric
+  start <- gsub(",\\s((Inf)|([\\-\\.0-9]+))\\)$", "", start)
+  start <- as.numeric(start)
+
+  # remove right ")"
+  end <- gsub("\\)$", "", name)
+  # remove left "[", left endpoint, ", "
+  # left endpoint can be negative infinity or any numeric
+  end <- gsub("^\\[((-Inf)|([\\-\\.0-9]+)),\\s", "", end)
+  end <- as.numeric(end)
+
   result <- list(start = start,
                  end = end)
   return(result)


### PR DESCRIPTION
Addresses #26. @krpaulson27 you were right that it was an issue in how I was identifying numeric values, worked for integers but not other stuff.

